### PR TITLE
feat: support if-none-match for the extension list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## (next)
+
+- Support if-none-match for the extension list endpoint
+
 ## v1.0.14
 
 - feat(chart): split image.name into image.registry + image.name

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/rs/zerolog"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_sdk"
@@ -24,6 +26,8 @@ import (
 	"github.com/steadybit/extension-newrelic/extworkload"
 )
 
+var startedAt = time.Now().Format(time.RFC3339)
+
 func main() {
 	extlogging.InitZeroLog()
 	extbuild.PrintBuildInformation()
@@ -34,13 +38,14 @@ func main() {
 	exthealth.SetReady(false)
 	exthealth.StartProbes(8091)
 
-	exthttp.RegisterHttpHandler("/", exthttp.GetterAsHandler(getExtensionList))
 	discovery_kit_sdk.Register(extworkload.NewWorkloadDiscovery())
 	discovery_kit_sdk.Register(extaccount.NewAccountDiscovery())
 	action_kit_sdk.RegisterAction(extworkload.NewWorkloadCheckAction())
 	action_kit_sdk.RegisterAction(extaccount.NewCreateMutingRuleAction())
 	action_kit_sdk.RegisterAction(extincident.NewIncidentCheckAction())
 	extevents.RegisterEventListenerHandlers()
+
+	exthttp.RegisterHttpHandler("/", exthttp.IfNoneMatchHandler(func() string { return startedAt }, exthttp.GetterAsHandler(getExtensionList)))
 
 	extsignals.ActivateSignalHandlers()
 	action_kit_sdk.RegisterCoverageEndpoints()


### PR DESCRIPTION
## Summary
- Wrap the `"/"` index handler with `exthttp.IfNoneMatchHandler` using a startup timestamp as ETag
- Allows clients to skip re-fetching the unchanged extension list via `If-None-Match` header
- Move index handler registration to after all action/discovery registrations for consistency

## Test plan
- [ ] Verify extension starts and responds to `GET /` with an `ETag` header
- [ ] Verify `GET /` with matching `If-None-Match` header returns `304 Not Modified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)