### PR TITLE
fix: prevent GraphQL injection and handler panics in New Relic calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- fix: escape values interpolated into New Relic GraphQL queries and build the request envelope with a JSON encoder, preventing query/JSON injection via muting-rule name/description, workload/entity guids and incident priorities
+- fix: do not panic when delivering events while New Relic accounts could not be loaded, or when an incident has no description
+- fix: set a timeout on the New Relic HTTP client so a slow or unresponsive API cannot block discovery, status checks or event delivery indefinitely
+
 ## v1.0.19
 
 - chore(deps): bump alpine from 3.23 to 3.24

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,25 @@ type Specification struct {
 
 var (
 	Config Specification
+	// httpClient is shared and has a timeout so a slow or unresponsive New Relic API
+	// cannot block discovery, status checks or event delivery indefinitely.
+	httpClient = &http.Client{Timeout: 30 * time.Second}
 )
+
+// graphQlRequestBody builds the `{"query": ...}` request envelope. Using json.Marshal
+// (rather than hand-formatting the JSON) ensures the query is correctly escaped.
+func graphQlRequestBody(query string) []byte {
+	body, _ := json.Marshal(map[string]string{"query": query})
+	return body
+}
+
+// graphQlString renders a value as a quoted, escaped GraphQL string literal so that
+// quotes, backslashes or newlines in the value cannot break out of the literal and
+// inject into the surrounding query (JSON string escaping is valid for GraphQL).
+func graphQlString(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}
 
 func ParseConfiguration() {
 	err := envconfig.Process("steadybit_extension", &Config)
@@ -53,7 +71,7 @@ const accountsQuery = `{actor {accounts {id}}}`
 func (s *Specification) GetAccountIds(_ context.Context) ([]int64, error) {
 	url := fmt.Sprintf("%s/graphql", s.ApiBaseUrl)
 
-	responseBody, response, err := s.do(url, "POST", fmt.Appendf(nil, "{\"query\": \"%s\"}", accountsQuery), s.ApiKey)
+	responseBody, response, err := s.do(url, "POST", graphQlRequestBody(accountsQuery), s.ApiKey)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get accounts from New Relic. Full response %+v", string(responseBody))
 		return nil, err
@@ -92,7 +110,7 @@ const workloadQuery = `{actor {account(id: %d){workload {collections {guid name 
 func (s *Specification) GetWorkloads(_ context.Context, accountId int64) ([]types.Workload, error) {
 	url := fmt.Sprintf("%s/graphql", s.ApiBaseUrl)
 
-	responseBody, response, err := s.do(url, "POST", fmt.Appendf(nil, "{\"query\": \"%s\"}", fmt.Sprintf(workloadQuery, accountId)), s.ApiKey)
+	responseBody, response, err := s.do(url, "POST", graphQlRequestBody(fmt.Sprintf(workloadQuery, accountId)), s.ApiKey)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get workloads from New Relic. Full response %+v", string(responseBody))
 		return nil, err
@@ -120,12 +138,12 @@ func (s *Specification) GetWorkloads(_ context.Context, accountId int64) ([]type
 	}
 }
 
-const workloadStatusQuery = `{actor {account(id: %d){ workload { collection(guid: \"%s\") {status {value}}}}}}`
+const workloadStatusQuery = `{actor {account(id: %d){ workload { collection(guid: %s) {status {value}}}}}}`
 
 func (s *Specification) GetWorkloadStatus(_ context.Context, workloadGuid string, accountId int64) (*string, error) {
 	url := fmt.Sprintf("%s/graphql", s.ApiBaseUrl)
 
-	responseBody, response, err := s.do(url, "POST", fmt.Appendf(nil, "{\"query\": \"%s\"}", fmt.Sprintf(workloadStatusQuery, accountId, workloadGuid)), s.ApiKey)
+	responseBody, response, err := s.do(url, "POST", graphQlRequestBody(fmt.Sprintf(workloadStatusQuery, accountId, graphQlString(workloadGuid))), s.ApiKey)
 	if err != nil {
 		log.Error().Err(err).Str("workloadGuid", workloadGuid).Msgf("Failed to get workload status from New Relic. Full response %+v", string(responseBody))
 		return nil, err
@@ -159,12 +177,12 @@ func (s *Specification) GetWorkloadStatus(_ context.Context, workloadGuid string
 	}
 }
 
-const mutingRuleCreate = `mutation{alertsMutingRuleCreate(accountId: %d rule: {condition: {conditions: {attribute: \"accountId\", operator: EQUALS, values: \"%d\"}, operator: AND}, name: \"%s\", schedule: {endTime: \"%s\", timeZone: \"UTC\"}, description: \"%s\", enabled: true}  ) {id}}`
+const mutingRuleCreate = `mutation{alertsMutingRuleCreate(accountId: %d rule: {condition: {conditions: {attribute: "accountId", operator: EQUALS, values: "%d"}, operator: AND}, name: %s, schedule: {endTime: "%s", timeZone: "UTC"}, description: %s, enabled: true}  ) {id}}`
 
 func (s *Specification) CreateMutingRule(_ context.Context, accountId int64, name string, description string, end time.Time) (*string, error) {
 	url := fmt.Sprintf("%s/graphql", s.ApiBaseUrl)
 	endString := end.UTC().Format("2006-01-02T15:04:05")
-	responseBody, response, err := s.do(url, "POST", fmt.Appendf(nil, "{\"query\": \"%s\"}", fmt.Sprintf(mutingRuleCreate, accountId, accountId, name, endString, description)), s.ApiKey)
+	responseBody, response, err := s.do(url, "POST", graphQlRequestBody(fmt.Sprintf(mutingRuleCreate, accountId, accountId, graphQlString(name), endString, graphQlString(description))), s.ApiKey)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to create muting rule in New Relic. Full response %+v", string(responseBody))
 		return nil, err
@@ -197,7 +215,7 @@ const mutingRuleDelete = `mutation {alertsMutingRuleDelete(id: %s, accountId: %d
 
 func (s *Specification) DeleteMutingRule(_ context.Context, accountId int64, mutingRuleId string) error {
 	url := fmt.Sprintf("%s/graphql", s.ApiBaseUrl)
-	responseBody, response, err := s.do(url, "POST", fmt.Appendf(nil, "{\"query\": \"%s\"}", fmt.Sprintf(mutingRuleDelete, mutingRuleId, accountId)), s.ApiKey)
+	responseBody, response, err := s.do(url, "POST", graphQlRequestBody(fmt.Sprintf(mutingRuleDelete, graphQlString(mutingRuleId), accountId)), s.ApiKey)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to delete muting rule in New Relic. Full response %+v", string(responseBody))
 		return err
@@ -211,12 +229,12 @@ func (s *Specification) DeleteMutingRule(_ context.Context, accountId int64, mut
 	return nil
 }
 
-const entityTagsQuery = `{actor {entities(guids: \"%s\"){tags {key values}}}}`
+const entityTagsQuery = `{actor {entities(guids: %s){tags {key values}}}}`
 
 func (s *Specification) GetEntityTags(_ context.Context, guid string) (map[string][]string, error) {
 	url := fmt.Sprintf("%s/graphql", s.ApiBaseUrl)
 
-	responseBody, response, err := s.do(url, "POST", fmt.Appendf(nil, "{\"query\": \"%s\"}", fmt.Sprintf(entityTagsQuery, guid)), s.ApiKey)
+	responseBody, response, err := s.do(url, "POST", graphQlRequestBody(fmt.Sprintf(entityTagsQuery, graphQlString(guid))), s.ApiKey)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get entity tags from New Relic. Full response %+v", string(responseBody))
 		return nil, err
@@ -263,9 +281,9 @@ func (s *Specification) GetIncidents(_ context.Context, incidentPriorityFilter [
 		if i > 0 {
 			priorityFilter.WriteString(",")
 		}
-		priorityFilter.WriteString(fmt.Sprintf("\\\"%s\\\"", priority))
+		priorityFilter.WriteString(graphQlString(priority))
 	}
-	responseBody, response, err := s.do(url, "POST", fmt.Appendf(nil, "{\"query\": \"%s\"}", fmt.Sprintf(incidentsQuery, accountId, priorityFilter.String())), s.ApiKey)
+	responseBody, response, err := s.do(url, "POST", graphQlRequestBody(fmt.Sprintf(incidentsQuery, accountId, priorityFilter.String())), s.ApiKey)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get incidents from New Relic. Full response %+v", string(responseBody))
 		return nil, err
@@ -339,8 +357,7 @@ func (s *Specification) do(url string, method string, body []byte, apiKey string
 	request.Header.Set("Content-Type", "application/json; charset=UTF-8")
 	request.Header.Set("API-Key", apiKey)
 
-	client := &http.Client{}
-	response, err := client.Do(request)
+	response, err := httpClient.Do(request)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to execute request")
 		return nil, response, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 steadybit GmbH. All rights reserved.
+ */
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGraphQlStringEscaping(t *testing.T) {
+	got := graphQlString(`a"b\c` + "\n")
+	want := `"a\"b\\c\n"`
+	if got != want {
+		t.Errorf("graphQlString = %s, want %s", got, want)
+	}
+}
+
+func TestCreateMutingRuleEscapesInjection(t *testing.T) {
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"alertsMutingRuleCreate":{"id":"42"}}}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	// A name/description that tries to break out of the GraphQL string literal.
+	maliciousName := `exp", enabled: false, x: "`
+	maliciousDescription := "line1\nline2\\\"end"
+
+	id, err := s.CreateMutingRule(context.Background(), 123, maliciousName, maliciousDescription, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == nil || *id != "42" {
+		t.Fatalf("expected muting rule id 42, got %v", id)
+	}
+
+	// The request envelope must remain valid JSON despite the quotes/newlines/backslashes.
+	var envelope map[string]string
+	if err := json.Unmarshal(captured, &envelope); err != nil {
+		t.Fatalf("request body is not valid JSON (injection broke the envelope): %v\nbody: %s", err, captured)
+	}
+
+	// The malicious inputs must be carried as escaped GraphQL string literals, not as raw query text.
+	query := envelope["query"]
+	if !strings.Contains(query, "name: "+graphQlString(maliciousName)) {
+		t.Errorf("name was not embedded as an escaped literal: %s", query)
+	}
+	if !strings.Contains(query, "description: "+graphQlString(maliciousDescription)) {
+		t.Errorf("description was not embedded as an escaped literal: %s", query)
+	}
+}

--- a/extevents/extevents.go
+++ b/extevents/extevents.go
@@ -73,10 +73,17 @@ func handle(handler eventHandler) func(w http.ResponseWriter, r *http.Request, b
 
 		if request, err := handler(&event); err == nil {
 			if request != nil {
-				for _, accountId := range accountCache.Get(accountCacheKey).Value() {
-					eventErr := config.Config.PostEvent(r.Context(), request, accountId)
-					if eventErr != nil {
-						log.Err(eventErr).Int64("accountId", accountId).Msgf("Failed to send event to New Relic.")
+				// Get returns nil when the loader failed to fetch accounts (e.g. New Relic
+				// unreachable); guard against it instead of dereferencing a nil item.
+				accountItem := accountCache.Get(accountCacheKey)
+				if accountItem == nil {
+					log.Warn().Msg("No New Relic accounts available; skipping event delivery.")
+				} else {
+					for _, accountId := range accountItem.Value() {
+						eventErr := config.Config.PostEvent(r.Context(), request, accountId)
+						if eventErr != nil {
+							log.Err(eventErr).Int64("accountId", accountId).Msgf("Failed to send event to New Relic.")
+						}
 					}
 				}
 			}

--- a/extincident/incident_check.go
+++ b/extincident/incident_check.go
@@ -328,13 +328,17 @@ func toMetric(incident types.Incident, now time.Time) action_kit_api.Metric {
 	if len(title) == 0 {
 		title = incident.Title
 	}
+	description := ""
+	if len(incident.Description) > 0 {
+		description = incident.Description[0]
+	}
 	return action_kit_api.Metric{
 		Name: new("new_relic_incidents"),
 		Metric: map[string]string{
 			"newrelic.incident-id": incident.IncidentId,
 			"title":                title,
 			"state":                "danger",
-			"tooltip":              fmt.Sprintf("Priority: %s\nTitle: %s\nDescription: %s\nEntity: %s", incident.Priority, incident.Title, incident.Description[0], incident.EntityNames),
+			"tooltip":              fmt.Sprintf("Priority: %s\nTitle: %s\nDescription: %s\nEntity: %s", incident.Priority, incident.Title, description, incident.EntityNames),
 		},
 		Timestamp: now,
 		Value:     0,


### PR DESCRIPTION
## Problems

**MAJOR — GraphQL/JSON injection.** Queries were assembled by hand-formatting the JSON envelope (`fmt.Appendf(nil, "{\"query\": \"%s\"}", ...)`) and interpolating values straight into GraphQL string literals (`name: \"%s\"`, `guids: \"%s\"`, etc.). A value containing a quote, backslash or newline — muting-rule **name**/**description** (derived from the experiment), workload/entity **guids**, incident **priorities** — could break out of the literal and inject into the query or corrupt the request body.

**HIGH — nil-deref panic on event delivery.** `accountCache.Get(accountCacheKey).Value()` was called unguarded. `ttlcache.Get` returns `nil` when the loader failed (e.g. New Relic unreachable), so every inbound experiment event panicked while accounts couldn't be loaded.

**HIGH — index panic on incidents.** `incident.Description[0]` was indexed without a length check; an incident with no description panicked the check.

**MAJOR — no HTTP client timeout.** `do()` built a fresh `&http.Client{}` per call with no timeout, so a slow/unresponsive New Relic API could block discovery, status checks and event delivery indefinitely (and never reused connections).

## Fixes

- Build the request envelope with `json.Marshal` (`graphQlRequestBody`) and render interpolated values as escaped GraphQL string literals via `graphQlString` (JSON string-escaping is a valid GraphQL string-literal encoding). **Query structure is unchanged for valid inputs** — only the escaping of injected values changes.
- Guard the account-cache lookup: skip delivery with a warning when accounts are unavailable, instead of dereferencing a nil item.
- Guard `incident.Description[0]` with a length check (empty-string fallback).
- Use a shared `http.Client{Timeout: 30s}` for all New Relic calls.

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- New `config/config_test.go`: asserts `graphQlString` escaping and that a muting-rule **name** containing a GraphQL breakout payload keeps the request body valid JSON and is carried as an escaped literal (injection neutralized).
- Full suite incl. **e2e** (minikube) passes locally — exercises account discovery, workloads, workload status, incidents, entity tags, and muting-rule create/delete through the new envelope.

## Notes
- Chose value-escaping over a GraphQL **variables** rewrite deliberately: escaping keeps every query structurally identical (far lower risk for a security patch, and validated by the passing e2e), and `json.Marshal` is a complete escaping boundary for GraphQL string literals. Migrating to variables is a reasonable non-urgent follow-up.
- A `/simplify` pass (4 agents) flagged one optional cleanup — a `doGraphQl` helper to collapse the pre-existing `url`+`POST`+`ApiKey` boilerplate across the 7 query methods. Left out to keep this security fix focused; noted as a follow-up.