### PR TITLE
fix: surface New Relic GraphQL errors instead of silently degrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- fix: fail the incident check instead of reporting "no incidents" when New Relic rejects the incidents query, e.g. because the API key's user lacks the required role
+- fix: log the operation, account and rejected field path for New Relic GraphQL errors, which are reported with HTTP 200 and were previously logged without any hint about which query failed
+- fix: do not panic when New Relic answers with a null `data`, `workload` or `aiIssues` payload, as it does for queries the API key's user is not permitted to run
+- fix: continue workload discovery with the remaining accounts when one account cannot be read
+
 ## v1.0.23
 
 - chore(deps): update dependencies

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,21 @@ func graphQlString(value string) string {
 	return string(encoded)
 }
 
+// graphQlErrors renders the GraphQL-level errors of a response as a single string, or
+// "" if there are none. New Relic answers authorization problems ("user's role doesn't
+// permit this action") and field timeouts with HTTP 200 and a populated `errors` array,
+// so these are the only indication that a query returned partial or no data.
+func graphQlErrors(result *types.GraphQlResponse) string {
+	if result.Errors == nil || len(*result.Errors) == 0 {
+		return ""
+	}
+	messages := make([]string, 0, len(*result.Errors))
+	for i := range *result.Errors {
+		messages = append(messages, (*result.Errors)[i].String())
+	}
+	return strings.Join(messages, "; ")
+}
+
 func ParseConfiguration() {
 	err := envconfig.Process("steadybit_extension", &Config)
 	if err != nil {
@@ -89,8 +104,13 @@ func (s *Specification) GetAccountIds(_ context.Context) ([]int64, error) {
 			log.Error().Err(err).Str("body", string(responseBody)).Msgf("Failed to parse body")
 			return nil, err
 		}
-		if result.Errors != nil && len(*result.Errors) > 0 {
-			log.Warn().Msgf("API returned errors %+v", result.Errors)
+		if errs := graphQlErrors(&result); errs != "" {
+			log.Warn().Str("operation", "accounts").Str("errors", errs).Msg("New Relic API returned errors.")
+		}
+
+		if result.Data == nil || result.Data.Actor == nil {
+			log.Error().Str("body", string(responseBody)).Msg("Response contains no accounts.")
+			return nil, errors.New("unexpected response body")
 		}
 
 		accounts := make([]int64, 0, len(result.Data.Actor.Accounts))
@@ -128,8 +148,12 @@ func (s *Specification) GetWorkloads(_ context.Context, accountId int64) ([]type
 			log.Error().Err(err).Str("body", string(responseBody)).Msgf("Failed to parse body")
 			return nil, err
 		}
-		if result.Errors != nil && len(*result.Errors) > 0 {
-			log.Warn().Msgf("API returned errors %+v", result.Errors)
+		if errs := graphQlErrors(&result); errs != "" {
+			log.Warn().Str("operation", "workloads").Int64("accountId", accountId).Str("errors", errs).Msg("New Relic API returned errors.")
+		}
+		if result.Data == nil || result.Data.Actor == nil || result.Data.Actor.Account == nil || result.Data.Actor.Account.Workload == nil {
+			log.Error().Int64("accountId", accountId).Str("body", string(responseBody)).Msg("Response contains no workloads.")
+			return nil, errors.New("unexpected response body")
 		}
 		return result.Data.Actor.Account.Workload.Collections, err
 	} else {
@@ -161,10 +185,11 @@ func (s *Specification) GetWorkloadStatus(_ context.Context, workloadGuid string
 			log.Error().Err(err).Str("body", string(responseBody)).Msgf("Failed to parse body")
 			return nil, err
 		}
-		if result.Errors != nil && len(*result.Errors) > 0 {
-			log.Warn().Msgf("API returned errors %+v", result.Errors)
+		if errs := graphQlErrors(&result); errs != "" {
+			log.Warn().Str("operation", "workloadStatus").Int64("accountId", accountId).Str("workloadGuid", workloadGuid).Str("errors", errs).Msg("New Relic API returned errors.")
 		}
-		if result.Data.Actor.Account.Workload.Collection != nil && result.Data.Actor.Account.Workload.Collection.Status != nil {
+		if result.Data != nil && result.Data.Actor != nil && result.Data.Actor.Account != nil && result.Data.Actor.Account.Workload != nil &&
+			result.Data.Actor.Account.Workload.Collection != nil && result.Data.Actor.Account.Workload.Collection.Status != nil {
 			return &result.Data.Actor.Account.Workload.Collection.Status.Value, err
 		}
 		//Workaround - New Relic has regular timeouts
@@ -202,6 +227,10 @@ func (s *Specification) CreateMutingRule(_ context.Context, accountId int64, nam
 		}
 		if result.Data != nil && result.Data.AlertsMutingRuleCreate != nil {
 			return &result.Data.AlertsMutingRuleCreate.Id, err
+		}
+		if errs := graphQlErrors(&result); errs != "" {
+			log.Error().Str("operation", "createMutingRule").Int64("accountId", accountId).Str("errors", errs).Msg("New Relic API returned errors.")
+			return nil, fmt.Errorf("New Relic API returned errors: %s", errs)
 		}
 		log.Error().Err(err).Msgf("Unexpected response body %+v", string(responseBody))
 		return nil, errors.New("unexpected response body")
@@ -252,11 +281,11 @@ func (s *Specification) GetEntityTags(_ context.Context, guid string) (map[strin
 			log.Error().Err(err).Str("body", string(responseBody)).Msgf("Failed to parse body")
 			return nil, err
 		}
-		if result.Errors != nil && len(*result.Errors) > 0 {
-			log.Warn().Msgf("API returned errors %+v", result.Errors)
+		if errs := graphQlErrors(&result); errs != "" {
+			log.Warn().Str("operation", "entityTags").Str("entityGuid", guid).Str("errors", errs).Msg("New Relic API returned errors.")
 		}
 
-		if len(result.Data.Actor.Entities) == 1 {
+		if result.Data != nil && result.Data.Actor != nil && len(result.Data.Actor.Entities) == 1 {
 			tags := make(map[string][]string)
 			for _, tag := range result.Data.Actor.Entities[0].Tags {
 				tags[tag.Key] = tag.Values
@@ -301,11 +330,18 @@ func (s *Specification) GetIncidents(_ context.Context, incidentPriorityFilter [
 			log.Error().Err(err).Str("body", string(responseBody)).Msgf("Failed to parse body")
 			return nil, err
 		}
-		if result.Errors != nil && len(*result.Errors) > 0 {
-			log.Warn().Msgf("API returned errors %+v", result.Errors)
+		errs := graphQlErrors(&result)
+		if errs != "" {
+			log.Warn().Str("operation", "incidents").Int64("accountId", accountId).Str("errors", errs).Msg("New Relic API returned errors.")
 		}
-		if result.Data != nil && result.Data.Actor.Account != nil && result.Data.Actor.Account.AiIssues != nil && result.Data.Actor.Account.AiIssues.Incidents != nil {
+		if result.Data != nil && result.Data.Actor != nil && result.Data.Actor.Account != nil && result.Data.Actor.Account.AiIssues != nil && result.Data.Actor.Account.AiIssues.Incidents != nil {
 			return result.Data.Actor.Account.AiIssues.Incidents.Incidents, err
+		}
+		// No incidents payload at all. If New Relic reported errors (a missing permission
+		// answers with `aiIssues: null` and HTTP 200) we must not report an empty list:
+		// the incident check would read that as "no incidents" and silently pass.
+		if errs != "" {
+			return nil, fmt.Errorf("New Relic API returned errors: %s", errs)
 		}
 		return []types.Incident{}, nil
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -230,7 +230,7 @@ func (s *Specification) CreateMutingRule(_ context.Context, accountId int64, nam
 		}
 		if errs := graphQlErrors(&result); errs != "" {
 			log.Error().Str("operation", "createMutingRule").Int64("accountId", accountId).Str("errors", errs).Msg("New Relic API returned errors.")
-			return nil, fmt.Errorf("New Relic API returned errors: %s", errs)
+			return nil, fmt.Errorf("errors returned by the New Relic API: %s", errs)
 		}
 		log.Error().Err(err).Msgf("Unexpected response body %+v", string(responseBody))
 		return nil, errors.New("unexpected response body")
@@ -341,7 +341,7 @@ func (s *Specification) GetIncidents(_ context.Context, incidentPriorityFilter [
 		// answers with `aiIssues: null` and HTTP 200) we must not report an empty list:
 		// the incident check would read that as "no incidents" and silently pass.
 		if errs != "" {
-			return nil, fmt.Errorf("New Relic API returned errors: %s", errs)
+			return nil, fmt.Errorf("errors returned by the New Relic API: %s", errs)
 		}
 		return []types.Incident{}, nil
 	} else {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+
+	"github.com/steadybit/extension-newrelic/types"
 	"testing"
 	"time"
 )
@@ -59,5 +61,134 @@ func TestCreateMutingRuleEscapesInjection(t *testing.T) {
 	}
 	if !strings.Contains(query, "description: "+graphQlString(maliciousDescription)) {
 		t.Errorf("description was not embedded as an escaped literal: %s", query)
+	}
+}
+
+// New Relic reports authorization problems with HTTP 200 and a populated errors array.
+// The rendered error must name the rejected field so the log identifies the query.
+func TestGraphQlErrorsIncludePathAndErrorClass(t *testing.T) {
+	var result types.GraphQlResponse
+	body := `{"data":{"actor":{"account":{"aiIssues":null}}},"errors":[{"extensions":{"errorClass":"UNAUTHORIZED"},"path":["actor","account","aiIssues","incidents"],"message":"user's role doesn't permit this action"}]}`
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := graphQlErrors(&result)
+	want := "actor.account.aiIssues.incidents: user's role doesn't permit this action (UNAUTHORIZED)"
+	if got != want {
+		t.Errorf("graphQlErrors = %q, want %q", got, want)
+	}
+}
+
+// Path elements may be list indices rather than field names - those must not break parsing.
+func TestGraphQlErrorsWithListIndexInPath(t *testing.T) {
+	var result types.GraphQlResponse
+	body := `{"errors":[{"path":["actor","entities",0,"tags"],"message":"boom"}]}`
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := graphQlErrors(&result)
+	want := "actor.entities.0.tags: boom"
+	if got != want {
+		t.Errorf("graphQlErrors = %q, want %q", got, want)
+	}
+}
+
+func TestGraphQlErrorsEmptyWhenNoErrors(t *testing.T) {
+	var result types.GraphQlResponse
+	if err := json.Unmarshal([]byte(`{"data":{"actor":{"accounts":[{"id":1}]}}}`), &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := graphQlErrors(&result); got != "" {
+		t.Errorf("graphQlErrors = %q, want empty", got)
+	}
+}
+
+// A permission error must not degrade to "no incidents" - that would let an incident
+// check pass while it cannot see incidents at all.
+func TestGetIncidentsFailsOnUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"account":{"aiIssues":null}}},"errors":[{"extensions":{"errorClass":"UNAUTHORIZED"},"path":["actor","account","aiIssues"],"message":"user's role doesn't permit this action"}]}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	incidents, err := s.GetIncidents(context.Background(), []string{"CRITICAL"}, 123)
+	if err == nil {
+		t.Fatalf("expected an error, got incidents %+v", incidents)
+	}
+	if !strings.Contains(err.Error(), "user's role doesn't permit this action") {
+		t.Errorf("error does not carry the API message: %v", err)
+	}
+}
+
+// An account without incidents legitimately answers with an empty list - still no error.
+func TestGetIncidentsEmptyWithoutErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"account":{"aiIssues":{"incidents":{"incidents":[]}}}}}}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	incidents, err := s.GetIncidents(context.Background(), []string{"CRITICAL"}, 123)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(incidents) != 0 {
+		t.Errorf("expected no incidents, got %+v", incidents)
+	}
+}
+
+// A top-level error can come with `data: null` - discovery must error out, not panic.
+func TestGetAccountIdsWithNullData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":null,"errors":[{"message":"user's role doesn't permit this action"}]}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	if _, err := s.GetAccountIds(context.Background()); err == nil {
+		t.Error("expected an error for a response without data")
+	}
+}
+
+// A permission error on the workload query yields `workload: null` - must not panic.
+func TestGetWorkloadsWithNullWorkload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"account":{"workload":null}}},"errors":[{"path":["actor","account","workload"],"message":"user's role doesn't permit this action"}]}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	if _, err := s.GetWorkloads(context.Background(), 123); err == nil {
+		t.Error("expected an error for a response without workloads")
+	}
+}
+
+// The same for the status query, which falls back to UNKNOWN rather than failing.
+func TestGetWorkloadStatusWithNullWorkload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"account":{"workload":null}}},"errors":[{"path":["actor","account","workload"],"message":"user's role doesn't permit this action"}]}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	status, err := s.GetWorkloadStatus(context.Background(), "guid-1", 123)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status == nil || *status != "UNKNOWN" {
+		t.Errorf("expected status UNKNOWN, got %v", status)
 	}
 }

--- a/extworkload/workload_discovery.go
+++ b/extworkload/workload_discovery.go
@@ -101,8 +101,10 @@ func getAllWorkloads(ctx context.Context, api GetWorkloadsApi) []discovery_kit_a
 	for _, accountId := range accounts {
 		workloads, err := api.GetWorkloads(ctx, accountId)
 		if err != nil {
+			// Keep going: a single account the API key's user isn't authorized for must not
+			// hide the workloads of all remaining accounts.
 			log.Err(err).Int64("accountId", accountId).Msgf("Failed to get workloads from New Relic.")
-			return result
+			continue
 		}
 
 		for _, workload := range workloads {

--- a/types/types.go
+++ b/types/types.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"fmt"
+	"strings"
+)
+
 type EventType string
 
 const (
@@ -94,8 +99,40 @@ type GraphQlResponseTags struct {
 
 type GraphQlResponseError struct {
 	Message string `json:"message"`
+	// Path is the field the error refers to. Elements are either field names or list
+	// indices, hence []any.
+	Path       []any                           `json:"path"`
+	Extensions *GraphQlResponseErrorExtensions `json:"extensions"`
+}
+
+type GraphQlResponseErrorExtensions struct {
+	ErrorClass string `json:"errorClass"`
+	Code       string `json:"code"`
 }
 
 func (e *GraphQlResponseError) Error() string {
 	return e.Message
+}
+
+// String renders the error including the field path and the error class, e.g.
+// `actor.account.workload: user's role doesn't permit this action (UNAUTHORIZED)`.
+// The message alone doesn't say which part of the query New Relic rejected.
+func (e *GraphQlResponseError) String() string {
+	var sb strings.Builder
+	for i, segment := range e.Path {
+		if i > 0 {
+			sb.WriteString(".")
+		}
+		_, _ = fmt.Fprint(&sb, segment)
+	}
+	if sb.Len() > 0 {
+		sb.WriteString(": ")
+	}
+	sb.WriteString(e.Message)
+	if e.Extensions != nil && e.Extensions.ErrorClass != "" {
+		sb.WriteString(" (")
+		sb.WriteString(e.Extensions.ErrorClass)
+		sb.WriteString(")")
+	}
+	return sb.String()
 }


### PR DESCRIPTION
Follow-up to the `WRN API returned errors &[{Message:user's role doesn't permit this action}]` we see in the wild.

New Relic answers authorization problems and field timeouts with **HTTP 200** and a populated `errors` array, so the `StatusCode != 200` check passes and the error only ended up in a warning while the code carried on with whatever `data` came back. Three consequences, all fixed here.

### The warning wasn't diagnosable

It named neither the query nor the account, so in a multi-account setup — `{actor{accounts{id}}}` returns every account the key can *see*, and we then query each one — you had to enable debug logging to find out which account/field was rejected. `GraphQlResponseError` now also parses `path` and `extensions.errorClass`, and a shared `graphQlErrors` helper replaces the five copies of the log line:

```
WRN New Relic API returned errors errors="actor.account.aiIssues.incidents: user's role doesn't permit this action (UNAUTHORIZED)" operation=incidents accountId=1234567
```

`path` is modelled as `[]any` because segments can be list indices (`["actor","entities",0,"tags"]`), which `[]string` would have failed to unmarshal.

### The incident check passed while blind

`GetIncidents` degraded a rejected query to `[]types.Incident{}, nil`, so a check that could not see incidents at all reported "no incidents found" — a false negative in an experiment. It now returns an error when the payload is missing *and* the API reported errors; `IncidentCheckStatus` already turns that into an action error. A genuinely empty account (`incidents: []`, no errors) still returns an empty list. `CreateMutingRule` similarly discarded the errors array and returned a bare `unexpected response body`.

### A latent panic

`workload: null` / `aiIssues: null` / `data: null` — exactly what a permission error returns — were dereferenced through nil pointers in `GetAccountIds`, `GetWorkloads`, `GetWorkloadStatus` and `GetEntityTags`. A top-level auth error would have crashed discovery. All guarded now; `GetWorkloadStatus` keeps its existing `UNKNOWN` fallback.

Additionally, `getAllWorkloads` aborted the whole loop on one account's failure, dropping the workloads of every account after it — now it continues, since an unauthorized account is the likeliest cause of this warning.

### Verification

`gofmt`, `go vet`, `go test ./...` clean, including the e2e suite. 7 new tests in `config/config_test.go` cover the error rendering (path + errorClass, list index in path, no errors), the incidents error-vs-empty distinction, and the three former panic paths.

No release entry beyond `## Unreleased` — these are `fix:` commits, so Monday's auto-patch release will classify them unsafe and skip.