### PR TITLE
fix: discover the organization's managed accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: discover the organization's managed accounts instead of `actor.accounts`, which also contains the organization's internal storage account and caused permission errors on workload discovery and failed event delivery
 - fix: fail the incident check instead of reporting "no incidents" when New Relic rejects the incidents query, e.g. because the API key's user lacks the required role
 - fix: log the operation, account and rejected field path for New Relic GraphQL errors, which are reported with HTTP 200 and were previously logged without any hint about which query failed
 - fix: do not panic when New Relic answers with a null `data`, `workload` or `aiIssues` payload, as it does for queries the API key's user is not permitted to run

--- a/config/config.go
+++ b/config/config.go
@@ -81,7 +81,50 @@ func ValidateConfiguration() {
 	// You may optionally validate the configuration here.
 }
 
-const accountsQuery = `{actor {accounts {id}}}`
+// accountsQuery asks for the organization's managed accounts, which is the authoritative
+// list of accounts to operate on. `actor.accounts` alone is not: it also contains the
+// organization's storage account, an internal account holding organization-level data that
+// no role has workload, incident or event permissions on, so querying it yields nothing but
+// permission errors.
+//
+// Reading the organization requires a permission the API key's user may not have, so
+// `actor.accounts` and `storageAccountId` are requested in the same round trip as a
+// fallback - see accountIds.
+const accountsQuery = `{actor {accounts {id} organization {accountManagement {managedAccounts {id isCanceled}} storageAccountId}}}`
+
+// accountIds picks the accounts to operate on, preferring the organization's managed
+// accounts. It reports whether that list was available; if it wasn't, it falls back to
+// `actor.accounts` without the storage account.
+func accountIds(actor *types.GraphQlResponseActor) ([]int64, bool) {
+	var storageAccountId int64
+	if actor.Organization != nil {
+		if actor.Organization.StorageAccountId != nil {
+			storageAccountId = *actor.Organization.StorageAccountId
+		}
+		if actor.Organization.AccountManagement != nil && len(actor.Organization.AccountManagement.ManagedAccounts) > 0 {
+			managed := actor.Organization.AccountManagement.ManagedAccounts
+			accounts := make([]int64, 0, len(managed))
+			for _, account := range managed {
+				if account.IsCanceled {
+					continue
+				}
+				accounts = append(accounts, account.Id)
+			}
+			return accounts, true
+		}
+	}
+
+	accounts := make([]int64, 0, len(actor.Accounts))
+	for _, account := range actor.Accounts {
+		// Without the organization we cannot know the storage account id, so this only
+		// filters it out when `storageAccountId` alone was readable.
+		if account.Id == storageAccountId {
+			continue
+		}
+		accounts = append(accounts, account.Id)
+	}
+	return accounts, false
+}
 
 func (s *Specification) GetAccountIds(_ context.Context) ([]int64, error) {
 	url := fmt.Sprintf("%s/graphql", s.ApiBaseUrl)
@@ -104,19 +147,25 @@ func (s *Specification) GetAccountIds(_ context.Context) ([]int64, error) {
 			log.Error().Err(err).Str("body", string(responseBody)).Msgf("Failed to parse body")
 			return nil, err
 		}
-		if errs := graphQlErrors(&result); errs != "" {
-			log.Warn().Str("operation", "accounts").Str("errors", errs).Msg("New Relic API returned errors.")
-		}
+		errs := graphQlErrors(&result)
 
 		if result.Data == nil || result.Data.Actor == nil {
-			log.Error().Str("body", string(responseBody)).Msg("Response contains no accounts.")
+			log.Error().Str("operation", "accounts").Str("errors", errs).Str("body", string(responseBody)).Msg("Response contains no accounts.")
 			return nil, errors.New("unexpected response body")
 		}
 
-		accounts := make([]int64, 0, len(result.Data.Actor.Accounts))
-		for _, account := range result.Data.Actor.Accounts {
-			accounts = append(accounts, account.Id)
+		accounts, managed := accountIds(result.Data.Actor)
+		if errs != "" {
+			// Not being allowed to read the organization is expected for some API keys and
+			// handled by the fallback, so it is only worth a warning if it cost us the
+			// authoritative account list.
+			event := log.Debug()
+			if !managed {
+				event = log.Warn()
+			}
+			event.Str("operation", "accounts").Str("errors", errs).Msg("New Relic API returned errors.")
 		}
+		log.Debug().Bool("managedAccounts", managed).Ints64("accounts", accounts).Msg("Resolved New Relic accounts.")
 
 		return accounts, err
 	} else {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -159,6 +159,84 @@ func TestGetAccountIdsWithNullData(t *testing.T) {
 	}
 }
 
+// The organization's managed accounts are authoritative: the storage account
+// (4942247 here) must not be operated on, only the managed account (2847806).
+func TestGetAccountIdsUsesManagedAccounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"accounts":[{"id":2847806},{"id":4942247}],"organization":{"accountManagement":{"managedAccounts":[{"id":2847806,"isCanceled":false}]},"storageAccountId":4942247}}}}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	accounts, err := s.GetAccountIds(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(accounts) != 1 || accounts[0] != 2847806 {
+		t.Errorf("expected only the managed account 2847806, got %v", accounts)
+	}
+}
+
+func TestGetAccountIdsSkipsCanceledAccounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"organization":{"accountManagement":{"managedAccounts":[{"id":1,"isCanceled":false},{"id":2,"isCanceled":true}]},"storageAccountId":9}}}}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	accounts, err := s.GetAccountIds(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(accounts) != 1 || accounts[0] != 1 {
+		t.Errorf("expected only the active account 1, got %v", accounts)
+	}
+}
+
+// An API key whose user may not read the organization must keep working: fall back to
+// actor.accounts, still without the storage account if that field alone was readable.
+func TestGetAccountIdsFallsBackToActorAccounts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"accounts":[{"id":2847806},{"id":4942247}],"organization":{"accountManagement":null,"storageAccountId":4942247}}},"errors":[{"path":["actor","organization","accountManagement"],"message":"user's role doesn't permit this action"}]}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	accounts, err := s.GetAccountIds(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(accounts) != 1 || accounts[0] != 2847806 {
+		t.Errorf("expected the storage account to be filtered out, got %v", accounts)
+	}
+}
+
+// Without any organization data there is nothing to filter by - keep the old behaviour
+// rather than reporting no accounts at all.
+func TestGetAccountIdsFallsBackWithoutOrganization(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"actor":{"accounts":[{"id":2847806}],"organization":null}},"errors":[{"path":["actor","organization"],"message":"user's role doesn't permit this action"}]}`))
+	}))
+	defer server.Close()
+
+	s := &Specification{ApiBaseUrl: server.URL, ApiKey: "test-key"}
+
+	accounts, err := s.GetAccountIds(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(accounts) != 1 || accounts[0] != 2847806 {
+		t.Errorf("expected the accounts from actor.accounts, got %v", accounts)
+	}
+}
+
 // A permission error on the workload query yields `workload: null` - must not panic.
 func TestGetWorkloadsWithNullWorkload(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/types/types.go
+++ b/types/types.go
@@ -53,9 +53,26 @@ type GraphQlResponseAlertsMutingRuleCreate struct {
 	Id string `json:"id"`
 }
 type GraphQlResponseActor struct {
-	Account  *GraphQlResponseAccount   `json:"account"`
-	Accounts []GraphQlResponseAccounts `json:"accounts"`
-	Entities []GraphQlResponseEntities `json:"entities"`
+	Account      *GraphQlResponseAccount      `json:"account"`
+	Accounts     []GraphQlResponseAccounts    `json:"accounts"`
+	Entities     []GraphQlResponseEntities    `json:"entities"`
+	Organization *GraphQlResponseOrganization `json:"organization"`
+}
+
+type GraphQlResponseOrganization struct {
+	AccountManagement *GraphQlResponseAccountManagement `json:"accountManagement"`
+	// StorageAccountId is the organization's internal storage account. It shows up in
+	// `actor.accounts` but is not an account to operate on.
+	StorageAccountId *int64 `json:"storageAccountId"`
+}
+
+type GraphQlResponseAccountManagement struct {
+	ManagedAccounts []GraphQlResponseManagedAccount `json:"managedAccounts"`
+}
+
+type GraphQlResponseManagedAccount struct {
+	Id         int64 `json:"id"`
+	IsCanceled bool  `json:"isCanceled"`
 }
 type GraphQlResponseAccount struct {
 	Workload *WorkloadResponse `json:"workload"`


### PR DESCRIPTION
Fixes the permission warnings and event 403s seen on demo-develop, [diagnosed in #sig-* thread](https://steadybithq.slack.com/archives/C02K21Y6H5Y/p1785838780254369?thread_ts=1785835600.872879&cid=C02K21Y6H5Y).

### The problem

`{actor{accounts{id}}}` does not return the accounts to operate on. It also contains the organization's **storage account** — an internal account holding organization-level data. No role grants workload, incident or event permissions on it, so the extension queried an account it can never read:

```
WRN New Relic API returned errors. accountId=4942247 errors="actor.account.workload.collections: user's role doesn't permit this action (SERVER_ERROR)" operation=workloads
ERR Failed to send event to New Relic. error="unexpected response code" accountId=4942247
```

The 403 on event delivery has the same root cause: `PostEvent` builds `/v1/accounts/4942247/events` from the discovered id while the INGEST key belongs to the real account.

### The fix

Ask for the organization's managed accounts, which is authoritative, and skip `isCanceled` accounts so a cancelled account produces no permission noise either:

```graphql
{actor {accounts {id} organization {accountManagement {managedAccounts {id isCanceled}} storageAccountId}}}
```

For the affected org this returns `2847806` only, and no longer the storage account `4942247`.

### Why `actor.accounts` is still in the query

Reading `organization` requires a permission the API key's user may not have. Switching to `managedAccounts` alone would return **zero** accounts for those keys — no targets, no events — a far worse regression than the warning being fixed. So `actor.accounts` and `storageAccountId` come along in the same round trip and serve as a fallback, still filtering the storage account out when that field alone was readable.

Consequently the organization permission error is logged at `warn` only when it cost us the authoritative list, and at `debug` when the fallback covered it — otherwise keys without org access would warn every 30s.

### Tests

4 new cases in `config/config_test.go`: managed accounts win (using the exact response from the Slack thread), cancelled accounts skipped, fallback with `storageAccountId`, fallback with no organization at all. `gofmt`, `go vet`, `go test ./...` clean including e2e.

### Not addressed

`managedAccounts` can include accounts in other regions, which a single `STEADYBIT_EXTENSION_API_BASE_URL` cannot serve — a multi-region organization could see permission errors for cross-region accounts. Not the case for this organization (one account, `eu01`), and filtering by `regionCode` would mean guessing the base-url-to-region mapping, so I'd rather handle it if it actually shows up.